### PR TITLE
Update flexmeasures.markdown

### DIFF
--- a/source/_integrations/flexmeasures.markdown
+++ b/source/_integrations/flexmeasures.markdown
@@ -161,7 +161,8 @@ The S2 Protocol is a communication standard for devices with energy flexibility.
 It supports sending descriptions of energy flexibility and preference for activation between a Resource Manager (RM) and a Customer Energy Manager (CEM).
 
 This integration allows running Home Assistant as a CEM, by receiving and sending S2 messages with websockets and using FlexMeasures to optimize device activation.
-That way, users can change the control type of a resource manager in Home Assistant.
+
+Scheduling recommendations automatically start when a RM sends a system description and/or state changes. For RMs that allow multiple control types, users can switch between them in Home Assistant.
 
 ## Changing the control type
 


### PR DESCRIPTION
Clear up S2 functionality.

At least, this is the workflow I think we have in mind for the CEM. We could choose to comment on when exactly schedule recommendations are triggered (i.e. possibly not with *every* state message), but I consider it more of an implementation detail.